### PR TITLE
update deprecated method addListener

### DIFF
--- a/dynamicAdapt.js
+++ b/dynamicAdapt.js
@@ -55,7 +55,7 @@ DynamicAdapt.prototype.init = function () {
 		const оbjectsFilter = Array.prototype.filter.call(this.оbjects, function (item) {
 			return item.breakpoint === mediaBreakpoint;
 		});
-		matchMedia.addListener(function () {
+		matchMedia.addEventListener("change", function () {
 			_this.mediaHandler(matchMedia, оbjectsFilter);
 		});
 		this.mediaHandler(matchMedia, оbjectsFilter);


### PR DESCRIPTION
This feature is no longer recommended. Though some browsers might still support it, it may have already been removed from the relevant web standards, may be in the process of being dropped, or may only be kept for compatibility purposes.
https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList/addListener